### PR TITLE
chore: add requirements.txt with initial dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+astroid==4.0.4
+dill==0.4.1
+isort==7.0.0
+mccabe==0.7.0
+numpy==2.4.2
+platformdirs==4.9.2
+pylint==4.0.4
+tomlkit==0.14.0


### PR DESCRIPTION
A requirements.txt file is missing, so one has been added to make the getting started process simpler.

Initial dependencies include:
- NumPy
- Pylint